### PR TITLE
Improve DB resource consumption

### DIFF
--- a/pkg/api/service/checkstates.go
+++ b/pkg/api/service/checkstates.go
@@ -43,14 +43,38 @@ func (c states) LessOrEqual(s string) []string {
 	}
 	return res
 }
+
+func (c states) High(s string) []string {
+	res := []string{}
+	for i := len(c) - 1; i >= 0; i-- {
+		x := sort.SearchStrings(c[i], s)
+		if x < len(c[i]) && c[i][x] == s {
+			break
+		}
+		res = append(res, c[i]...)
+	}
+	return res
+}
+
+func (c states) IsHigher(s, base string) bool {
+	for _, v := range c.High(base) {
+		if s == v {
+			return true
+		}
+	}
+	return false
+}
+
 func (c states) Terminal() []string {
 	return c[len(c)-1]
 }
+
 func (c states) IsTerminal(s string) bool {
 	t := c.Terminal()
 	x := sort.SearchStrings(t, s)
 	return (x < len(t) && t[x] == s)
 }
+
 func init() {
 	checkStates.Init()
 }

--- a/pkg/api/service/checkstates_test.go
+++ b/pkg/api/service/checkstates_test.go
@@ -1,0 +1,206 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLessOrEqual(t *testing.T) {
+	testCases := []struct {
+		state string
+		want  []string
+	}{
+		{
+			"CREATED",
+			[]string{"CREATED"},
+		},
+		{
+			"QUEUED",
+			[]string{"CREATED", "QUEUED"},
+		},
+		{
+			"ASSIGNED",
+			[]string{"CREATED", "QUEUED", "ASSIGNED"},
+		},
+		{
+			"RUNNING",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING"},
+		},
+		{
+			"PURGING",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING"},
+		},
+		{
+			"MALFORMED",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"ABORTED",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"KILLED",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"FAILED",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"FINISHED",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"TIMEOUT",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"INCONCLUSIVE",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		// Corner case to support upsert when agent pushes log and report data
+		// within a check message without explicit status.
+		{
+			"",
+			[]string{"CREATED", "QUEUED", "ASSIGNED", "RUNNING", "PURGING",
+				"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+	}
+
+	for _, tc := range testCases {
+		if states := checkStates.LessOrEqual(tc.state); !reflect.DeepEqual(states, tc.want) {
+			t.Fatalf("expected:\n%v\nbut got:\n%v", tc.want, states)
+		}
+	}
+}
+
+func TestHigh(t *testing.T) {
+	testCases := []struct {
+		state string
+		want  []string
+	}{
+		{
+			"CREATED",
+			[]string{"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT",
+				"PURGING", "RUNNING", "ASSIGNED", "QUEUED"},
+		},
+		{
+			"QUEUED",
+			[]string{"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT",
+				"PURGING", "RUNNING", "ASSIGNED"},
+		},
+		{
+			"ASSIGNED",
+			[]string{"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT",
+				"PURGING", "RUNNING"},
+		},
+		{
+			"RUNNING",
+			[]string{"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT",
+				"PURGING"},
+		},
+		{
+			"PURGING",
+			[]string{"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT"},
+		},
+		{
+			"ABORTED",
+			[]string{},
+		},
+		{
+			"FAILED",
+			[]string{},
+		},
+		{
+			"FINISHED",
+			[]string{},
+		},
+		{
+			"INCONCLUSIVE",
+			[]string{},
+		},
+		{
+			"KILLED",
+			[]string{},
+		},
+		{
+			"MALFORMED",
+			[]string{},
+		},
+		{
+			"TIMEOUT",
+			[]string{},
+		},
+		// Corner case to support upsert when agent pushes log and report data
+		// within a check message without explicit status.
+		{
+			"",
+			[]string{"ABORTED", "FAILED", "FINISHED", "INCONCLUSIVE", "KILLED", "MALFORMED", "TIMEOUT",
+				"PURGING", "RUNNING", "ASSIGNED", "QUEUED", "CREATED"},
+		},
+	}
+
+	for _, tc := range testCases {
+		if states := checkStates.High(tc.state); !reflect.DeepEqual(states, tc.want) {
+			t.Fatalf("expected:\n%v\nbut got:\n%v", tc.want, states)
+		}
+	}
+}
+
+func TestIsHigher(t *testing.T) {
+	testCases := []struct {
+		status string
+		base   string
+		want   bool
+	}{
+		{
+			status: "CREATED",
+			base:   "CREATED",
+			want:   false,
+		},
+		{
+			status: "QUEUED",
+			base:   "CREATED",
+			want:   true,
+		},
+		{
+			status: "FINISHED",
+			base:   "INCONCLUSIVE",
+			want:   false,
+		},
+		{
+			status: "FINISHED",
+			base:   "FINISHED",
+			want:   false,
+		},
+		{
+			status: "ABORTED",
+			base:   "PURGING",
+			want:   true,
+		},
+		{
+			status: "ASSIGNED",
+			base:   "RUNNING",
+			want:   false,
+		},
+		{
+			status: "RUNNING",
+			base:   "ASSIGNED",
+			want:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		if got := checkStates.IsHigher(tc.status, tc.base); got != tc.want {
+			t.Fatalf("expected IsHigher for %s against %s to be %v, but got %v",
+				tc.status, tc.base, tc.want, got)
+		}
+	}
+}

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -356,7 +356,7 @@ func (s ScansService) ProcessScanCheckNotification(ctx context.Context, msg []by
 
 	// Only update scan and checks data if there is an status change.
 	// Intermediate check messages data (e.g.: progress reporting) are not persisted.
-	if checkMssg.Status != dbCheck.Status {
+	if checkStates.IsHigher(checkMssg.Status, dbCheck.Status) {
 		checkCount, err := s.db.UpsertCheck(scanID, checkID, checkMssg, checkStates.LessOrEqual(checkMssg.Status))
 		if err != nil {
 			return err

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -597,13 +597,13 @@ func mergeChecks(old api.Check, new api.Check) api.Check {
 	if new.Status != "" {
 		c.Status = new.Status
 	}
-	if new.Progress != nil {
+	if util.Ptr2Float(new.Progress) != 0 {
 		c.Progress = new.Progress
 	}
-	if new.Report != nil {
+	if util.Ptr2Str(new.Report) != "" {
 		c.Report = new.Report
 	}
-	if new.Raw != nil {
+	if util.Ptr2Str(new.Raw) != "" {
 		c.Raw = new.Raw
 	}
 	return c

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -308,88 +308,93 @@ func (s ScansService) checktypesByAssettype(ctx context.Context) (ChecktypesByAs
 func (s ScansService) ProcessScanCheckNotification(ctx context.Context, msg []byte) error {
 	_ = level.Debug(s.logger).Log("ProcessingMessage", string(msg))
 
-	c := api.Check{}
-	err := json.Unmarshal(msg, &c)
+	// Parse check mssg
+	checkMssg := api.Check{}
+	err := json.Unmarshal(msg, &checkMssg)
 	if err != nil {
 		_ = level.Error(s.logger).Log(err)
 		return nil
 	}
-	err = validator.New().Struct(c)
+	err = validator.New().Struct(checkMssg)
 	if err != nil {
 		_ = level.Error(s.logger).Log("ErrorValidatingCheckUpdateEvent", err)
 		return nil
 	}
-	checkID, err := uuid.FromString(c.ID)
+	checkMssg.Data = msg
+	checkProgress := util.Ptr2Float(checkMssg.Progress)
+
+	// Retrieve DB check
+	checkID, err := uuid.FromString(checkMssg.ID)
 	if err != nil {
 		_ = level.Error(s.logger).Log("NotValidCheckID", err)
-		return nil
 	}
-	scanID, err := s.db.GetScanIDForCheck(checkID)
+	dbCheck, err := s.db.GetCheckByID(checkID)
 	if err != nil {
 		_ = level.Error(s.logger).Log("CheckForMsgDoesNotExist", err)
 		return nil
 	}
-	c.ScanID = scanID.String()
-	id, err := uuid.FromString(c.ID)
+	scanID, err := uuid.FromString(dbCheck.ScanID)
 	if err != nil {
 		_ = level.Error(s.logger).Log("NotValidScanID", err)
 		return nil
 	}
-	c.Data = msg
-	progress := util.Ptr2Float(c.Progress)
 
-	// Don't take into account inconsistent progress in a message with a
-	// terminal status.
-	if checkStates.IsTerminal(c.Status) && (progress != 1.0) {
-		_ = level.Error(s.logger).Log("FixingInvalidProgressInTerminalStatus", progress, "Status", c.Status)
-		progress = 1
-		c.Progress = &progress
+	// Don't take into account inconsistent progress in a message with a terminal status.
+	if checkStates.IsTerminal(checkMssg.Status) && (checkProgress != 1.0) {
+		_ = level.Error(s.logger).Log("FixingInvalidProgressInTerminalStatus", checkProgress, "Status", checkMssg.Status)
+		checkProgress = 1
+		checkMssg.Progress = &checkProgress
 	}
 
-	// The progress could still be incorrect if the check is not in a terminal
-	// status. In that case we want to discard the message because we can not
-	// deduce the progress from the status.
-	if progress > 1.0 || progress < 0.0 {
-		_ = level.Error(s.logger).Log("NotValidProgress", c.Progress)
+	// The progress could still be incorrect if the check is not in a terminal status.
+	// In that case we want to discard the message because we can not deduce the progress
+	// from the status.
+	if checkProgress > 1.0 || checkProgress < 0.0 {
+		_ = level.Error(s.logger).Log("NotValidProgress", checkMssg.Progress)
 		return nil
 	}
 
-	checkCount, err := s.db.UpsertCheck(scanID, id, c, checkStates.LessOrEqual(c.Status))
-	if err != nil {
-		return err
-	}
-
-	// If the upsert didn't affect any check we have to try to update the status.
-	if checkCount == 0 {
-		_ = level.Info(s.logger).Log("NoEffectProcessingCheckUpdate", string(msg))
-	}
-	scanCount, scan, err := s.updateScanStatus(scanID)
-	if err != nil {
-		return err
-	}
-
-	if scanCount > 0 {
-		_ = level.Info(s.logger).Log("ScanStatusUpdated", string(msg))
-		_ = level.Debug(s.logger).Log("ScanStatusSet", scanID.String()+";"+util.Ptr2Str(scan.Status))
-	}
-
-	// If check message implies a status change from the
-	// one stored in DB, propagate it and push metrics.
-	if c.Status != "" && checkCount > 0 {
-		err = s.notifyCheck(checkID, util.Ptr2Str(scan.ExternalID))
+	// Only update scan and checks data if there is an status change.
+	// Intermediate check messages data (e.g.: progress reporting) are not persisted.
+	if checkMssg.Status != dbCheck.Status {
+		checkCount, err := s.db.UpsertCheck(scanID, checkID, checkMssg, checkStates.LessOrEqual(checkMssg.Status))
 		if err != nil {
 			return err
 		}
-	}
+		if checkCount == 0 {
+			_ = level.Info(s.logger).Log("NoEffectProcessingCheckUpdate", string(msg))
+		}
 
-	// If the current scans is finished and this check state update was the one
-	// that caused it to be in that state then we notify the scan is finished.
-	if scanCount > 0 && *scan.Status == ScanStatusFinished {
-		err = s.notifyScan(scanID)
+		scanCount, scan, err := s.updateScanStatus(scanID)
 		if err != nil {
 			return err
 		}
+		if scanCount > 0 {
+			_ = level.Info(s.logger).Log("ScanStatusUpdated", string(msg))
+			_ = level.Debug(s.logger).Log("ScanStatusSet", scanID.String()+";"+util.Ptr2Str(scan.Status))
+		}
+
+		check := mergeChecks(checkMssg, dbCheck)
+
+		// If check message implies a status change from the
+		// one stored in DB, propagate it and push metrics.
+		if checkMssg.Status != "" && checkCount > 0 {
+			err = s.notifyCheck(check, util.Ptr2Str(scan.ExternalID))
+			if err != nil {
+				return err
+			}
+		}
+
+		// If the current scans is finished and this check state update was the one
+		// that caused it to be in that state then we notify the scan is finished.
+		if scanCount > 0 && *scan.Status == ScanStatusFinished {
+			err = s.notifyScan(scanID)
+			if err != nil {
+				return err
+			}
+		}
 	}
+
 	return nil
 }
 
@@ -404,12 +409,7 @@ func (s ScansService) notifyScan(scanID uuid.UUID) error {
 	return s.scansNotifier.Push(scan.ToScanNotification(), nil)
 }
 
-func (s ScansService) notifyCheck(checkID uuid.UUID, programID string) error {
-	check, err := s.db.GetCheckByID(checkID)
-	if err != nil {
-		return err
-	}
-
+func (s ScansService) notifyCheck(check api.Check, programID string) error {
 	s.pushCheckMetrics(check, programID)
 
 	ctname := "unknown"
@@ -590,4 +590,21 @@ func statusFromChecks(scan api.Scan, checkStats map[string]int, n float32, l log
 	scan.Status = &status
 	scan.EndTime = endTime
 	return scan
+}
+
+func mergeChecks(old api.Check, new api.Check) api.Check {
+	c := old
+	if new.Status != "" {
+		c.Status = new.Status
+	}
+	if new.Progress != nil {
+		c.Progress = new.Progress
+	}
+	if new.Report != nil {
+		c.Report = new.Report
+	}
+	if new.Raw != nil {
+		c.Raw = new.Raw
+	}
+	return c
 }

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -356,7 +356,9 @@ func (s ScansService) ProcessScanCheckNotification(ctx context.Context, msg []by
 
 	// Only update scan and checks data if there is an status change.
 	// Intermediate check messages data (e.g.: progress reporting) are not persisted.
-	if checkStates.IsHigher(checkMssg.Status, dbCheck.Status) {
+	// We have to take into account the particular check message sent by the agent for
+	// report and raw data which does not state an explicit status.
+	if checkMssg.Status == "" || checkStates.IsHigher(checkMssg.Status, dbCheck.Status) {
 		checkCount, err := s.db.UpsertCheck(scanID, checkID, checkMssg, checkStates.LessOrEqual(checkMssg.Status))
 		if err != nil {
 			return err

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -374,7 +374,7 @@ func (s ScansService) ProcessScanCheckNotification(ctx context.Context, msg []by
 			_ = level.Debug(s.logger).Log("ScanStatusSet", scanID.String()+";"+util.Ptr2Str(scan.Status))
 		}
 
-		check := mergeChecks(checkMssg, dbCheck)
+		check := mergeChecks(dbCheck, checkMssg)
 
 		// If check message implies a status change from the
 		// one stored in DB, propagate it and push metrics.

--- a/pkg/scans/checksrunner.go
+++ b/pkg/scans/checksrunner.go
@@ -290,7 +290,8 @@ func (c *ChecksRunner) CreateScanChecks(id string) error {
 			ID:                      scan.ID,
 			LastCheckCreated:        &lastCheck,
 			LastTargetCheckGCreated: &last,
-			TargetGroups:            &[]api.TargetsChecktypesGroup{},
+			TargetGroups:            &[]api.TargetsChecktypesGroup{},  // Remove creation process data
+			ChecktypesInfo:          map[string]map[string]struct{}{}, // Remove creation process data
 		}
 		_, err = c.store.UpdateScan(scan.ID, updateScan, []string{service.ScanStatusRunning})
 		if err != nil {

--- a/pkg/scans/checksrunner.go
+++ b/pkg/scans/checksrunner.go
@@ -290,8 +290,7 @@ func (c *ChecksRunner) CreateScanChecks(id string) error {
 			ID:                      scan.ID,
 			LastCheckCreated:        &lastCheck,
 			LastTargetCheckGCreated: &last,
-			TargetGroups:            &[]api.TargetsChecktypesGroup{},  // Remove creation process data
-			ChecktypesInfo:          map[string]map[string]struct{}{}, // Remove creation process data
+			TargetGroups:            &[]api.TargetsChecktypesGroup{}, // Remove creation process data
 		}
 		_, err = c.store.UpdateScan(scan.ID, updateScan, []string{service.ScanStatusRunning})
 		if err != nil {

--- a/pkg/scans/checksrunner_test.go
+++ b/pkg/scans/checksrunner_test.go
@@ -364,6 +364,7 @@ func TestChecksRunner_CreateScanChecks(t *testing.T) {
 				wantScan.ChecksCreated = intToPtr(3)
 				wantScan.LastTargetCheckGCreated = intToPtr(1)
 				wantScan.LastCheckCreated = intToPtr(-1)
+				wantScan.TargetGroups = &[]api.TargetsChecktypesGroup{}
 				gotScan := store.scans[scan4ID]
 				scansDiff := cmp.Diff(wantScan, gotScan)
 				if scansDiff != "" {


### PR DESCRIPTION
This PR modifies vulcan-scanengine in order to limit the DB resources consumption. This is done in two ways:
- Delete the target groups data associated with a scan once its information has been competently pushed to the agents queue.
- Ignore intermediate check status messages when processing checks execution so these do not imply extra queries (updates in this case) in the DB.