### PR TITLE
Fix wrong reference to loop variables when notifying msgs to SNS

### DIFF
--- a/pkg/notify/snsnotifier.go
+++ b/pkg/notify/snsnotifier.go
@@ -75,21 +75,11 @@ func (s *SNSNotifier) Push(message interface{}, attributes map[string]string) er
 	if err != nil {
 		return err
 	}
-	var attrs map[string]*sns.MessageAttributeValue
-	if attributes != nil {
-		attrs = make(map[string]*sns.MessageAttributeValue)
-		t := "String"
-		for n, v := range attributes {
-			attrs[n] = &sns.MessageAttributeValue{
-				DataType:    &t,
-				StringValue: &v,
-			}
-		}
-	}
+
 	input := &sns.PublishInput{
 		Message:           aws.String(string(content)),
 		TopicArn:          aws.String(s.c.TopicArn),
-		MessageAttributes: attrs,
+		MessageAttributes: prepareMessageAttributes(attributes),
 	}
 
 	output, err := s.sns.Publish(input)
@@ -108,4 +98,22 @@ func (s *SNSNotifier) Push(message interface{}, attributes map[string]string) er
 		"Message", aws.StringValue(input.Message),
 		"MessageID", messageID)
 	return nil
+}
+
+func prepareMessageAttributes(attributes map[string]string) map[string]*sns.MessageAttributeValue {
+	var attrs map[string]*sns.MessageAttributeValue
+	if attributes != nil {
+		attrs = make(map[string]*sns.MessageAttributeValue)
+		t := "String"
+		for n, v := range attributes {
+			// See: https://bryce.is/writing/code/jekyll/update/2015/11/01/3-go-gotchas.html
+			localV := v
+			attrs[n] = &sns.MessageAttributeValue{
+				DataType:    &t,
+				StringValue: &localV,
+			}
+		}
+	}
+
+	return attrs
 }

--- a/pkg/notify/snsnotifier_test.go
+++ b/pkg/notify/snsnotifier_test.go
@@ -84,6 +84,40 @@ func TestSNSNotifier_Push(t *testing.T) {
 	}
 }
 
+func TestPrepareMessageAttributes(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		attributes map[string]string
+		want       map[string]*sns.MessageAttributeValue
+	}{
+		{
+			name:       "PushesMsgsToTopic",
+			attributes: map[string]string{"a": "ONE", "b": "TWO"},
+			want: map[string]*sns.MessageAttributeValue{
+				"a": {
+					DataType:    strToPtr("String"),
+					StringValue: strToPtr("ONE"),
+				},
+				"b": {
+					DataType:    strToPtr("String"),
+					StringValue: strToPtr("TWO"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prepareMessageAttributes(tt.attributes)
+
+			diff := cmp.Diff(got, tt.want)
+			if diff != "" {
+				t.Errorf("want != got. Diffs:%s", diff)
+			}
+		})
+	}
+}
+
 func strToPtr(s string) *string {
 	return &s
 }

--- a/pkg/notify/snsnotifier_test.go
+++ b/pkg/notify/snsnotifier_test.go
@@ -85,7 +85,6 @@ func TestSNSNotifier_Push(t *testing.T) {
 }
 
 func TestPrepareMessageAttributes(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		attributes map[string]string


### PR DESCRIPTION
This PR fix a problem when assembling the array of attributes to be sent to SNS.

The usage of the loop variable pointers inside the `for-range` has the effect of setting all `StringValue` references to the same memory address (same value).

The solution is to simply set a local variable, with LOOP scope only and use it to set the fields of  `attr`

See:  https://bryce.is/writing/code/jekyll/update/2015/11/01/3-go-gotchas.html