### PR TITLE
Retrieve tag and program id when getting scan stats

### DIFF
--- a/pkg/api/persistence/persistence.go
+++ b/pkg/api/persistence/persistence.go
@@ -253,13 +253,15 @@ func (db Persistence) GetCheckByID(id uuid.UUID) (api.Check, error) {
 func (db Persistence) GetScanStatus(ID uuid.UUID) (api.Scan, error) {
 	query := `SELECT data->>'status' as status, 
 	data->'checks_finished' as checks_finished,
-	data->'check_count' as check_count FROM scans WHERE id=?`
+	data->'check_count', data->>'tag', data->>'external_id' as check_count FROM scans WHERE id=?`
 	s := new(api.Scan)
 	var (
 		count, finished int
 		status          string
+		tag             string
+		externalID      string
 	)
-	rest := []interface{}{&status, &finished, &count}
+	rest := []interface{}{&status, &finished, &count, &tag, &externalID}
 	err := db.store.QueryRaw(query, rest, ID)
 	if err != nil {
 		return api.Scan{}, err
@@ -268,6 +270,8 @@ func (db Persistence) GetScanStatus(ID uuid.UUID) (api.Scan, error) {
 	s.Status = &status
 	s.CheckCount = &count
 	s.ChecksFinished = &finished
+	s.Tag = &tag
+	s.ExternalID = &externalID
 	return *s, nil
 }
 

--- a/pkg/api/persistence/persistence_test.go
+++ b/pkg/api/persistence/persistence_test.go
@@ -749,6 +749,8 @@ func TestPersistence_GetScanStatus(t *testing.T) {
 				Status:         util.Str2Ptr("RUNNING"),
 				CheckCount:     util.Int2Ptr(2),
 				ChecksFinished: util.Int2Ptr(1),
+				ExternalID:     util.Str2Ptr("1f5ae7c9-1fe8-4b3d-9507-ac41542728bb@periodic-full-scan"),
+				Tag:            util.Str2Ptr("sdrn:schibsted:team:security"),
 			},
 		},
 	}

--- a/pkg/api/persistence/persistence_test.go
+++ b/pkg/api/persistence/persistence_test.go
@@ -329,6 +329,8 @@ func TestPersistence_AddCheckAsFinished(t *testing.T) {
 			wantN:   1,
 			wantScan: api.Scan{
 				ID:             UUIDFromString(fixtureScans["Scan1"].ID),
+				ExternalID:     util.Str2Ptr("1f5ae7c9-1fe8-4b3d-9507-ac41542728bb@periodic-full-scan"),
+				Tag:            util.Str2Ptr("sdrn:schibsted:team:security"),
 				Status:         &runningState,
 				Progress:       testutil.FloatPointer(0.5),
 				CheckCount:     testutil.IntPointer(2),
@@ -441,6 +443,8 @@ func TestPersistence_GetScans(t *testing.T) {
 			want: []api.Scan{
 				{
 					ID:             UUIDFromString("c3b5af18-4e1d-11e8-9c2d-fa7ae01bbebc"),
+					ExternalID:     util.Str2Ptr("1f5ae7c9-1fe8-4b3d-9507-ac41542728bb@periodic-full-scan"),
+					Tag:            util.Str2Ptr("sdrn:schibsted:team:security"),
 					Status:         &runningState,
 					ChecksFinished: util.Int2Ptr(1),
 					Progress:       testutil.FloatPointer(0.5),
@@ -492,6 +496,8 @@ func TestPersistence_GetScans(t *testing.T) {
 			want: []api.Scan{
 				{
 					ID:             UUIDFromString("c3b5af18-4e1d-11e8-9c2d-fa7ae01bbebc"),
+					ExternalID:     util.Str2Ptr("1f5ae7c9-1fe8-4b3d-9507-ac41542728bb@periodic-full-scan"),
+					Tag:            util.Str2Ptr("sdrn:schibsted:team:security"),
 					ChecksFinished: util.Int2Ptr(1),
 					Status:         &runningState,
 					Progress:       testutil.FloatPointer(0.5),

--- a/pkg/api/persistence/testdata/store_test_fixtures/scans.yml
+++ b/pkg/api/persistence/testdata/store_test_fixtures/scans.yml
@@ -2,7 +2,8 @@
 
 # scans.yml
 - id : "c3b5af18-4e1d-11e8-9c2d-fa7ae01bbebc"
-  data: '{"id": "c3b5af18-4e1d-11e8-9c2d-fa7ae01bbebc", "checks_finished": 1, "check_count": 2, "checks_created": 1,  "status": "RUNNING", "progress": 0.5}'
+  data: '{"id": "c3b5af18-4e1d-11e8-9c2d-fa7ae01bbebc", "checks_finished": 1, "check_count": 2, "checks_created": 1,  "status": "RUNNING", "progress": 0.5, "tag": "sdrn:schibsted:team:security"
+  , "external_id": "1f5ae7c9-1fe8-4b3d-9507-ac41542728bb@periodic-full-scan"}'
   created_at: "2019-04-08 09:10:00.59883+00"
 
 - id: "a3b5af18-4e1d-11e8-9c2d-fa7ae01bbebc"

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -472,12 +472,13 @@ func (s ScansService) updateScanStatus(id uuid.UUID) (int64, string, error) {
 		update.EndTime = &now
 	}
 	n, err := s.db.UpdateScan(id, update, []string{ScanStatusRunning})
+	tag := buildScanTag(util.Ptr2Str(scan.Tag), util.Ptr2Str(scan.ExternalID))
 	// Push scan progress metrics.
 	s.metricsClient.Push(metrics.Metric{
 		Name:  scanCompletionMetric,
 		Typ:   metrics.Histogram,
 		Value: float64(util.Ptr2Float(update.Progress)),
-		Tags:  []string{componentTag, buildScanTag(util.Ptr2Str(scan.Tag), util.Ptr2Str(scan.ExternalID))},
+		Tags:  []string{componentTag, tag},
 	})
 
 	return n, status, err


### PR DESCRIPTION
This PR fixes a bug that was preventing to publish the metrics for a scan with the expected name.