### PR TITLE
Add dynamic queues config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ vendor/
 .DS_Store
 local.toml
 local.queues.yaml
+run.toml
 
 # Linux binary used in Dockerfile
 cmd/vulcan-scan-engine/vulcan-scan-engine
+

--- a/README.md
+++ b/README.md
@@ -76,8 +76,12 @@ Those are the variables you have to use:
 |CHECKS_CREATOR_WORKERS|Number of workers to run for checks creation||
 |CHECKS_CREATOR_PERIOD|Period (seconds) for which workers should look for checks pending to be created||
 |QUEUES_DEFAULT_ARN|Default checks queue ARN|arn:aws:sqs:xxx:123456789012:yyy|
-|QUEUES_NESSUS_ARN|Nessus checks ARN|arn:aws:sqs:xxx:123456789012:yyy|
-|QUEUES_NESSUS_CHECKTYPES|List of checks to create in nessus queue|["vulcan-nessus"]|
+|QUEUES_NESSUS_ARN|Nessus checks ARN *TO BE DEPRECATED*|arn:aws:sqs:xxx:123456789012:yyy|
+|QUEUES_NESSUS_CHECKTYPES|List of checks to create in nessus queue *TO BE DEPRECATED*|["vulcan-nessus"]|
+|QUEUES_1_ARN|checks ARN|arn:aws:sqs:xxx:123456789012:yyy|
+|QUEUES_1_CHECKTYPES|List of checks to create in this queue|["vulcan-checktype1"]|
+|QUEUES_2_ARN|Nessus checks ARN|arn:aws:sqs:xxx:123456789012:yyy|
+|QUEUES_2_CHECKTYPES|List of checks to create in this queue|["vulcan-checktype2","vulcan-checktype3"]|
 
 ```bash
 docker build . -t vse

--- a/cmd/vulcan-scan-engine/commands/config.go
+++ b/cmd/vulcan-scan-engine/commands/config.go
@@ -56,7 +56,9 @@ type checktypeQueueConfig map[string]checktypeQueues
 func (c checktypeQueueConfig) ARNs() map[string]string {
 	var qarns = make(map[string]string)
 	for qType, q := range c {
-		qarns[qType] = q.ARN
+		if q.ARN != "" {
+			qarns[qType] = q.ARN
+		}
 	}
 	return qarns
 }

--- a/config.toml
+++ b/config.toml
@@ -59,6 +59,6 @@ period =  $CHECKS_CREATOR_PERIOD
     # arn = "$QUEUES_1_ARN"
     # checktypes = $QUEUES_1_CHECKTYPES
 
-    # [queues.q1]
+    # [queues.q2]
     # arn = "$QUEUES_2_ARN"
     # checktypes = $QUEUES_2_CHECKTYPES

--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,16 @@ period =  $CHECKS_CREATOR_PERIOD
     [queues.default]
     arn = "$QUEUES_DEFAULT_ARN"
 
+    # This will be depracted in favor of a more dynamic way (see below)
     [queues.nessus]
     arn = "$QUEUES_NESSUS_ARN"
     checktypes = $QUEUES_NESSUS_CHECKTYPES
+
+    # This will be populated by run.sh with a dynamic list of queues based on env variables
+    # [queues.q1]
+    # arn = "$QUEUES_1_ARN"
+    # checktypes = $QUEUES_1_CHECKTYPES
+
+    # [queues.q1]
+    # arn = "$QUEUES_2_ARN"
+    # checktypes = $QUEUES_2_CHECKTYPES

--- a/local.env
+++ b/local.env
@@ -27,5 +27,14 @@ CHECKS_CREATOR_WORKERS=1
 CHECKS_CREATOR_PERIOD=30
 
 QUEUES_DEFAULT_ARN=arn:aws:sqs::xxx:123456789012:yyy
+
+# Those custom configs will be deprecated.
 QUEUES_NESSUS_ARN=arn:aws:sqs::xxx:123456789012:yyy
 QUEUES_NESSUS_CHECKTYPES=["vulcan-nessus"]
+
+# 1 based list of queues
+QUEUES_1_ARN=arn:aws:sqs::xxx:123456789012:xxxx
+QUEUES_1_CHECKTYPES=["vulcan-nessus"]
+
+QUEUES_2_ARN=arn:aws:sqs::xxx:123456789012:yyyy
+QUEUES_2_CHECKTYPES=["vulcan-burp"]


### PR DESCRIPTION
This pr aims to remove hardcoded queues from the config and allow to dynamically populate the list queues based on env variables.

This version is compatible with previous strategy (see Nessus) but this will be completely removed in future versions.

- It will honor QUEUES_NESSUS_ARN / QUEUES_NESSUS_CHECKTYPES if informed.
- It will add a queue for each QUEUES_n_ARN / QUEUES_n_CHECKTYPE (n a sequence from 1)
