### PR TITLE
Add logs with data about scan creations

### DIFF
--- a/pkg/api/endpoint/middleware/logging.go
+++ b/pkg/api/endpoint/middleware/logging.go
@@ -27,7 +27,7 @@ func Logging(logger log.Logger) endpoint.Middleware {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			begin := time.Now()
 			response, err = next(ctx, request)
-			_ = level.Debug(logger).Log("request", toStr(request), "response", toStr(response), "transport_error", err, "took", time.Since(begin))
+			_ = level.Debug(logger).Log("Request", toStr(request), "Response", toStr(response), "TransportError", err, "Took", time.Since(begin))
 			return response, err
 		}
 	}

--- a/pkg/api/endpoint/middleware/logging.go
+++ b/pkg/api/endpoint/middleware/logging.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-kit/kit/endpoint"
 	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log/level"
 )
 
 func toStr(obj interface{}) string {
@@ -26,7 +27,7 @@ func Logging(logger log.Logger) endpoint.Middleware {
 		return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 			begin := time.Now()
 			response, err = next(ctx, request)
-			_ = logger.Log("request", toStr(request), "response", toStr(response), "transport_error", err, "took", time.Since(begin))
+			_ = level.Debug(logger).Log("request", toStr(request), "response", toStr(response), "transport_error", err, "took", time.Since(begin))
 			return response, err
 		}
 	}

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -246,7 +246,7 @@ func (s ScansService) CreateScan(ctx context.Context, scan *api.Scan) (uuid.UUID
 	if scan.Tag != nil {
 		tag = *scan.Tag
 	}
-	_ = level.Debug(s.logger).Log("ScanCreated", id, "CreationTime", time2Create.String(), "ExternalID",
+	_ = level.Info(s.logger).Log("ScanCreated", id, "CreationTime", time2Create.String(), "ExternalID",
 		externalID, "Tag", tag)
 	go func() {
 		err := s.ccreator.CreateScanChecks(id.String())

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -237,7 +237,17 @@ func (s ScansService) CreateScan(ctx context.Context, scan *api.Scan) (uuid.UUID
 
 	// Push metrics.
 	s.pushScanMetrics(metricsScanCreated, util.Ptr2Str(scan.Tag), util.Ptr2Str(scan.ExternalID), stats)
-	_ = level.Warn(s.logger).Log("ScanCreated", id)
+	time2Create := time.Since(*scan.StartTime)
+	externalID := ""
+	if scan.ExternalID != nil {
+		externalID = *scan.ExternalID
+	}
+	tag := ""
+	if scan.Tag != nil {
+		tag = *scan.Tag
+	}
+	_ = level.Debug(s.logger).Log("ScanCreated", id, "CreationTime", time2Create.String(), "ExternalID",
+		externalID, "Tag", tag)
 	go func() {
 		err := s.ccreator.CreateScanChecks(id.String())
 		if err != nil {
@@ -252,7 +262,7 @@ func (s ScansService) getScanStats(ctx context.Context, checktypesInfo Checktype
 		NumberOfChecksPerChecktype: map[string]int{},
 	}
 	if scan.TargetGroups == nil {
-		// If this field is nil it means this scan is using a versión of the
+		// If this field is nil it means this scan is using a version of the
 		// create scan request that does not support metrics any more, just
 		// return empty stats.
 		return scanStats{}, nil


### PR DESCRIPTION
This PR just add more data to the logs when a scan is created.
Concretely: 
* The time it took to create a scan.
*  The tag of the scan.
* The external id of the scan.