### PR TITLE
Clean checktypes_info when scan is created

### DIFF
--- a/pkg/api/scan.go
+++ b/pkg/api/scan.go
@@ -24,6 +24,10 @@ var (
 	CheckStateInconclusive = "INCONCLUSIVE"
 )
 
+// ChecktypesByAssettypes is used as a lookup table to check if a checktype can
+// be run against a concrete assettype.
+type ChecktypesByAssettypes map[string]map[string]struct{}
+
 // Scan holds all the data related to a scan.
 type Scan struct {
 	ID              uuid.UUID                 `json:"id,omitempty"`
@@ -41,11 +45,11 @@ type Scan struct {
 	CheckCount      *int                      `json:"check_count,omitempty"`
 	AbortedAt       *time.Time                `json:"aborted_at,omitempty"`
 
-	LastTargetCheckGCreated *int                           `json:"last_target_check_g_created,omitempty"`
-	LastCheckCreated        *int                           `json:"last_check_created,omitempty"`
-	ChecksCreated           *int                           `json:"checks_created,omitempty"`
-	ChecksFinished          *int                           `json:"checks_finished,omitempty"`
-	ChecktypesInfo          map[string]map[string]struct{} `json:"checkstypes_info,omitempty"`
+	LastTargetCheckGCreated *int                    `json:"last_target_check_g_created,omitempty"`
+	LastCheckCreated        *int                    `json:"last_check_created,omitempty"`
+	ChecksCreated           *int                    `json:"checks_created,omitempty"`
+	ChecksFinished          *int                    `json:"checks_finished,omitempty"`
+	ChecktypesInfo          *ChecktypesByAssettypes `json:"checkstypes_info,omitempty"`
 }
 
 // ScanNotification represents the data of a scan sent to an SNS topic.

--- a/pkg/api/service/scans.go
+++ b/pkg/api/service/scans.go
@@ -213,7 +213,7 @@ func (s ScansService) CreateScan(ctx context.Context, scan *api.Scan) (uuid.UUID
 	if err != nil {
 		return uuid.Nil, err
 	}
-	scan.ChecktypesInfo = ctypesInfo
+	scan.ChecktypesInfo = &ctypesInfo
 	stats, err := s.getScanStats(ctx, ctypesInfo, scan)
 	if err != nil {
 		return uuid.Nil, err
@@ -245,7 +245,7 @@ func (s ScansService) CreateScan(ctx context.Context, scan *api.Scan) (uuid.UUID
 	return id, nil
 }
 
-func (s ScansService) getScanStats(ctx context.Context, checktypesInfo ChecktypesByAssettypes, scan *api.Scan) (scanStats, error) {
+func (s ScansService) getScanStats(ctx context.Context, checktypesInfo api.ChecktypesByAssettypes, scan *api.Scan) (scanStats, error) {
 	stats := scanStats{
 		NumberOfChecksPerChecktype: map[string]int{},
 	}
@@ -278,12 +278,12 @@ func (s ScansService) getScanStats(ctx context.Context, checktypesInfo Checktype
 	return stats, nil
 }
 
-func (s ScansService) checktypesByAssettype(ctx context.Context) (ChecktypesByAssettypes, error) {
+func (s ScansService) checktypesByAssettype(ctx context.Context) (api.ChecktypesByAssettypes, error) {
 	assettypes, err := s.ctInformer.GetAssettypes()
 	if err != nil {
 		return nil, err
 	}
-	ret := ChecktypesByAssettypes{}
+	ret := api.ChecktypesByAssettypes{}
 	for _, a := range *assettypes {
 		if a.Assettype == nil {
 			continue

--- a/pkg/api/service/scans_test.go
+++ b/pkg/api/service/scans_test.go
@@ -331,7 +331,7 @@ func TestScansService_CreateScan(t *testing.T) {
 				ChecksCreated:  intToPtr(0),
 				ChecksFinished: intToPtr(0),
 				Progress:       floatToPtr(0.0),
-				ChecktypesInfo: map[string]map[string]struct{}{"DomainName": {"vulcan-spf": {}}, "Hostname": {"vulcan-nessus": {}}, "IP": {}},
+				ChecktypesInfo: &api.ChecktypesByAssettypes{"DomainName": {"vulcan-spf": {}}, "Hostname": {"vulcan-nessus": {}}, "IP": {}},
 			},
 		},
 	}

--- a/pkg/scans/checksrunner.go
+++ b/pkg/scans/checksrunner.go
@@ -37,10 +37,6 @@ type JobSender interface {
 	Send(queueName string, checktypeName string, job Job) error
 }
 
-// ChecktypesByAssettypes is used as a lookup table to check if a checktype can
-// be run against a concrete assettype.
-type ChecktypesByAssettypes map[string]map[string]struct{}
-
 // ChecktypeInformer defines the services required by the JobCreator type to be
 // able to query information about checktypes.
 type ChecktypeInformer interface {
@@ -172,7 +168,7 @@ func (c *ChecksRunner) CreateScanChecks(id string) error {
 		return err
 	}
 
-	checktypesInfo := scan.ChecktypesInfo
+	checktypesInfo := *scan.ChecktypesInfo
 
 	// This variable holds the current target group.
 	currentTargetG := -1
@@ -301,8 +297,8 @@ func (c *ChecksRunner) CreateScanChecks(id string) error {
 			ChecksCreated:           &created,
 			LastCheckCreated:        &lastCheck,
 			LastTargetCheckGCreated: &last,
-			TargetGroups:            &[]api.TargetsChecktypesGroup{},  // Remove creation process data
-			ChecktypesInfo:          map[string]map[string]struct{}{}, // Remove creation process data
+			TargetGroups:            &[]api.TargetsChecktypesGroup{}, // Remove creation process data
+			ChecktypesInfo:          &api.ChecktypesByAssettypes{},   // Remove creation process data
 		}
 
 		level.Info(c.l).Log("Scan", scan.ID, "GeneratedChecks", checkpointCount, "Seconds", time.Since(start).Seconds())
@@ -400,7 +396,7 @@ func (c *ChecksRunner) createCheck(scan api.Scan, g api.TargetsChecktypesGroup, 
 // of the list of the valid pairs {targe1,checktype1} continue creating the
 // jobs.
 func (c *ChecksRunner) createChecksForGroup(scan api.Scan, group api.TargetsChecktypesGroup,
-	start int, checktypesInfo ChecktypesByAssettypes, checkCreated newCheck) error {
+	start int, checktypesInfo api.ChecktypesByAssettypes, checkCreated newCheck) error {
 	// We sort the targets and checktypes groups so, assuming they contain the
 	// same items, we will walk them in the same order in successive calls to
 	// this function.

--- a/pkg/scans/checksrunner_test.go
+++ b/pkg/scans/checksrunner_test.go
@@ -86,7 +86,7 @@ var (
 		},
 	}
 
-	jobsCheckTypesInfoTest = map[string]map[string]struct{}{
+	jobsCheckTypesInfoTest = api.ChecktypesByAssettypes{
 		"Hostname": {
 			"vulcan-http-headers": {},
 			"vulcan-nessus":       {},
@@ -144,7 +144,7 @@ var (
 			},
 		},
 
-		ChecktypesInfo: jobsCheckTypesInfoTest,
+		ChecktypesInfo: &jobsCheckTypesInfoTest,
 	}
 
 	scan4Checks = []api.Check{


### PR DESCRIPTION
The `omitempty` flag in `checkstypes_info` prevented to replace the current value with '{}' so this https://github.com/adevinta/vulcan-scan-engine/pull/49/commits/bda0ee7427f2e3a1407c4135687562175e385f82 doesn't works.

This pr updates the Scan struct to use the general practice of using a reference to the type (as in the other attributes).