### PR TITLE
fix scan marked as finished after creation

### DIFF
--- a/pkg/scans/checksrunner.go
+++ b/pkg/scans/checksrunner.go
@@ -155,13 +155,13 @@ func (c *ChecksRunner) CreateScanChecks(id string) error {
 	if *scan.CheckCount == checksCreated {
 		// Scans was already created.
 		level.Warn(c.l).Log("ScanAlreadyCreated", id)
-		return err
+		return nil
 	}
 
 	if scan.TargetGroups == nil || len(*scan.TargetGroups) == 0 {
 		// Scans with no target groups should not be RUNNING.
 		level.Warn(c.l).Log("ScanWithNoTargetGroups", id)
-		return err
+		return nil
 	}
 
 	// The checktypes info used to create the checks of a scan should be fixed


### PR DESCRIPTION
When a scan finish creating it removes TargetGroups.
Since ae85cd9 the scans are created by the workers.
When a worker tries to continue/start a scan validates if TargetGroups exists and if not marks the scan as FINISHED. This is very likely to happen if another worker finishes the scan before.

This pr revalidates the number of checks created before continuing.
Also removes the status change in the scan to FINISH, keeping just the one based in Time.